### PR TITLE
Write a Go program to convert hexadecimal to octal

### DIFF
--- a/program/convert-hexadecimal-to-octal/convert-hexadecimal-to-octal.go
+++ b/program/convert-hexadecimal-to-octal/convert-hexadecimal-to-octal.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func main() {
+	var hex string
+	fmt.Scanln(&hex)
+
+	// first convert to decimal
+	decimal, err := strconv.ParseInt(hex, 16, 64)
+
+	if err != nil {
+		fmt.Errorf("could not convert hex: %v to octal", hex)
+		os.Exit(1)
+	}
+
+	// convert the decimal to octal
+	oct := fmt.Sprintf("%o", decimal)
+	fmt.Printf("the octal for hex: %v is oct: %v \n", hex, oct)
+}


### PR DESCRIPTION
### Why:

<!-- If this PR is linked to any issue -->
<!-- please change #ISSUE_NUMBER to the respective issue number -->
<!-- For example, Closes codinasion/codinasion#2 -->
Closes codinasion/codinasion#1129 

### What's being changed:
- Go file added to convert a hexadecimal to octal
- Run by running the following command, go version >= 1.16
```
cd program
go run convert-hexadecimal-to-octal/convert-hexadecimal-to-octal.go
```
- Enter the input and get the output
Example:
```
➜  program git:(convert-hexadecimal-to-octal) ✗ go run convert-hexadecimal-to-octal/convert-hexadecimal-to-octal.go
beef
the octal for hex: beef is oct: 137357 
➜  program git:(convert-hexadecimal-to-octal) ✗ go run convert-hexadecimal-to-octal/convert-hexadecimal-to-octal.go
A
the octal for hex: A is oct: 12 
```
