### PR TITLE
Change `float` to `double` in `ConvertRupeesToPaise.dart`

### DIFF
--- a/program/convert-rupees-to-paise/ConvertRupeesToPaise.dart
+++ b/program/convert-rupees-to-paise/ConvertRupeesToPaise.dart
@@ -1,5 +1,5 @@
 void main(){
-  float rupees = 10;
-  float paise = rupees * 100;
+  double rupees = 10;
+  double paise = rupees * 100;
   print('$rupees rupees = $paise paise');
 }


### PR DESCRIPTION
### Why:
The data type float does not exist in Dart.

### What's being changed:
Changed float to double in ConvertRupeesToPaise.dart
