### PR TITLE
Closes #4665

### DIFF
--- a/program/print-diamond-pattern/PrintDiamondPattern.rb
+++ b/program/print-diamond-pattern/PrintDiamondPattern.rb
@@ -1,0 +1,23 @@
+module PrintDiamond
+
+  def self.print(num)
+
+    1.upto(num) do |i|
+      draw(num, i)
+    end
+
+    (num-1).downto(1) do |i|
+      draw(num, i)
+    end
+
+    return
+  end
+
+  def self.draw(num, i)
+    asterisks = "*" * i
+    spaces = " " * (num - i)
+    puts spaces + asterisks + (asterisks[1..])
+  end
+end
+
+PrintDiamond.print(5)


### PR DESCRIPTION
### Why:

Closes codinasion/codinasion#3554

### What's being changed:

Draws diamond pattern in Ruby

### Comment:

We can remove `return` [at line codinasion/codinasion#14](https://github.com/Fukurokudzu/program/blob/962b770d89d18eb21e4cc5857af2b5120f5730e4/program/print-diamond-pattern/PrintDiamondPattern.rb#L13), if we don't expect user to call method as `puts PrintDiamond.print(5)`

