### PR TITLE
C# example that converts any string to vowel case.

### DIFF
--- a/program/convert-string-to-vowelcase/ConvertStringToVowelcase.cs
+++ b/program/convert-string-to-vowelcase/ConvertStringToVowelcase.cs
@@ -1,4 +1,6 @@
-﻿public class ConvertStringToVowelcase
+using System;
+
+public class ConvertStringToVowelcase
 {
     public static void Main(string[] args)
     {

--- a/program/convert-string-to-vowelcase/ConvertStringToVowelcase.cs
+++ b/program/convert-string-to-vowelcase/ConvertStringToVowelcase.cs
@@ -1,0 +1,33 @@
+﻿public class ConvertStringToVowelcase
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine("Enter a text to convert");
+        var text = Console.ReadLine();
+        Console.WriteLine(ConvertTextToVowelCase(text ?? ""));
+        Console.ReadLine();
+    }
+
+    private static string ConvertTextToVowelCase(string text)
+    {
+        var result = string.Empty;
+
+        foreach (var letter in text)
+        {
+            switch (letter) { 
+                case 'a':
+                case 'e':
+                case 'i':
+                case 'o':
+                case 'u':
+                    result += char.ToUpper(letter);
+                    break;
+                default:
+                    result += char.ToLower(letter);
+                    break;
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
### Why:
C# example that converts any string to vowel case. In this code we are not including the letter Y as a vowel.

Closes codinasion/codinasion#3590 

### What's being changed:
I've added new file ConvertStringToVowelcase.cs, containing the C# version for the method that converts a string to vowelcase
